### PR TITLE
EXPLICIT-REF

### DIFF
--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -57,6 +57,10 @@ let rec modifyStore s ref nv = match s with
           if n = ref then AppendStore (n, nv, store1)
           else AppendStore (n, v, modifyStore store1 ref nv)
 ;;
+let setref ref v =
+    let s = get_store () in
+    s := modifyStore !s ref v
+;;
 
 type program = Program of expression;;
 

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -10,6 +10,7 @@ type expression =
   | ProcExp of symbol * expression
   | CallExp of expression * expression
   | NewRefExp of expression
+  | DerefExp of expression
 ;;
 
 type environment =
@@ -124,6 +125,8 @@ let rec valueOf exp env = match exp with
           applyProcedure p (valueOf arg env)
   | NewRefExp e ->
           RefVal (newRef (valueOf e env))
+  | DerefExp e ->
+          deref (expValToRef (valueOf e env))
 and applyProcedure p v = match p with
   | Procedure (var, body, senv) -> valueOf body (ExtendEnv (var, v, senv))
 ;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -9,6 +9,7 @@ type expression =
   | LetExp of symbol * expression * expression
   | ProcExp of symbol * expression
   | CallExp of expression * expression
+  | NewRefExp of expression
 ;;
 
 type environment =
@@ -32,7 +33,7 @@ let the_store = ref EmptyStore;;
 
 let getStore () = the_store;;
 let initializeStore = the_store := EmptyStore;;
-let new_ref v =
+let newRef v =
     let s = getStore () in
     let r = !s in
     let n = match r with
@@ -121,6 +122,8 @@ let rec valueOf exp env = match exp with
   | CallExp (func, arg) ->
           let p = expValToProc (valueOf func env) in
           applyProcedure p (valueOf arg env)
+  | NewRefExp e ->
+          RefVal (newRef (valueOf e env))
 and applyProcedure p v = match p with
   | Procedure (var, body, senv) -> valueOf body (ExtendEnv (var, v, senv))
 ;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -1,0 +1,96 @@
+type symbol = Symbol of string;;
+
+type expression =
+  | ConstExp of int
+  | DiffExp of expression * expression
+  | ZeroExp of expression
+  | IfExp of expression * expression * expression
+  | VarExp of symbol
+  | LetExp of symbol * expression * expression
+  | ProcExp of symbol * expression
+  | CallExp of expression * expression
+;;
+
+type environment =
+  | EmptyEnv
+  | ExtendEnv of symbol * expVal * environment
+and expVal =
+  | NumVal of int
+  | BoolVal of bool
+  | ProcVal of procedure
+and procedure =
+  | Procedure of symbol * expression * environment
+;;
+
+type program = Program of expression;;
+
+exception CannotConvertNonNumVal;;
+let expValToNum = function
+  | NumVal v -> v
+  | _ -> raise CannotConvertNonNumVal
+;;
+
+exception CannotConvertNonBoolVal;;
+let expValToBool = function
+  | BoolVal b -> b
+  | _ -> raise CannotConvertNonBoolVal
+;;
+
+exception CannotConvertNonProcVal;;
+let expValToProc = function
+  | ProcVal p -> p
+  | _ -> raise CannotConvertNonProcVal
+;;
+
+
+exception VariableNotFound;;
+let rec applyEnv env var = match env with
+  | EmptyEnv -> raise VariableNotFound
+  | ExtendEnv (var1, val1, env1) ->
+          if var = var1 then val1
+          else applyEnv env1 var
+;;
+
+
+let rec valueOf exp env = match exp with
+  | ConstExp n ->
+          NumVal n
+  | DiffExp (e1, e2) ->
+          let n1 = expValToNum (valueOf e1 env) in
+          let n2 = expValToNum (valueOf e2 env) in
+          NumVal (n1 - n2)
+  | ZeroExp e ->
+          BoolVal (0 = expValToNum (valueOf e env))
+  | IfExp (e1, e2, e3) ->
+          if expValToBool (valueOf e1 env)
+          then valueOf e2 env
+          else valueOf e3 env
+  | VarExp var ->
+          applyEnv env var
+  | LetExp (var, e, body) ->
+          valueOf body (ExtendEnv (var, (valueOf e env), env))
+  | ProcExp (var, body) ->
+          ProcVal (Procedure (var, body, env))
+  | CallExp (func, arg) ->
+          let p = expValToProc (valueOf func env) in
+          applyProcedure p (valueOf arg env)
+and applyProcedure p v = match p with
+  | Procedure (var, body, senv) -> valueOf body (ExtendEnv (var, v, senv))
+;;
+
+let valueOfProgram = function
+  | Program e -> valueOf e EmptyEnv
+;;
+
+
+let exp1 = DiffExp (ConstExp 5, ConstExp 3);;
+let pgm1 = Program exp1;;
+print_int (expValToNum (valueOfProgram pgm1));;
+
+let exp2 = LetExp (Symbol "x", ConstExp 5, DiffExp (VarExp (Symbol "x"), ConstExp 2));;
+let pgm2 = Program exp2;;
+print_int (expValToNum (valueOfProgram pgm2));;
+
+let exp3 = IfExp (ZeroExp (DiffExp (ConstExp 5, ConstExp 5)), exp1, exp2);;
+let pgm3 = Program exp3;;
+print_int (expValToNum (valueOfProgram pgm3));;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -51,6 +51,13 @@ let rec applyStore s ref = match s with
 ;;
 let deref ref = applyStore !(get_store ()) ref;;
 
+let rec modifyStore s ref nv = match s with
+  | EmptyStore  -> raise StoreNotFound
+  | AppendStore (n, v, store1) ->
+          if n = ref then AppendStore (n, nv, store1)
+          else AppendStore (n, v, modifyStore store1 ref nv)
+;;
+
 type program = Program of expression;;
 
 exception CannotConvertNonNumVal;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -27,7 +27,20 @@ type store =
   | AppendStore of int * expVal * store
 ;;
 
-let the_store = ref EmptyEnv;;
+let the_store = ref EmptyStore;;
+
+let get_store () = the_store;;
+let initialize_store = the_store := EmptyStore;;
+let new_ref v =
+    let s = get_store () in
+    let r = !s in
+    let n = match r with
+              | EmptyStore -> 0
+              | AppendStore (n, _, _) -> n
+    in
+    let newr = AppendStore (n+1, v, r) in
+    (s := newr; n+1)
+;;
 
 type program = Program of expression;;
 

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -11,6 +11,7 @@ type expression =
   | CallExp of expression * expression
   | NewRefExp of expression
   | DerefExp of expression
+  | SetRefExp of expression * expression
 ;;
 
 type environment =
@@ -127,6 +128,11 @@ let rec valueOf exp env = match exp with
           RefVal (newRef (valueOf e env))
   | DerefExp e ->
           deref (expValToRef (valueOf e env))
+  | SetRefExp (re, ve) ->
+          let r = expValToRef (valueOf re env) in
+          let v = valueOf ve env in
+          (setref r v; v)
+
 and applyProcedure p v = match p with
   | Procedure (var, body, senv) -> valueOf body (ExtendEnv (var, v, senv))
 ;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -22,6 +22,13 @@ and procedure =
   | Procedure of symbol * expression * environment
 ;;
 
+type store =
+  | EmptyStore
+  | AppendStore of int * expVal * store
+;;
+
+let the_store = ref EmptyEnv;;
+
 type program = Program of expression;;
 
 exception CannotConvertNonNumVal;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -42,6 +42,15 @@ let new_ref v =
     (s := newr; n+1)
 ;;
 
+exception StoreNotFound;;
+let rec applyStore s ref = match s with
+  | EmptyStore  -> raise StoreNotFound
+  | AppendStore (n, v, store1) ->
+          if n = ref then v
+          else applyStore store1 ref
+;;
+let deref ref = applyStore !(get_store ()) ref;;
+
 type program = Program of expression;;
 
 exception CannotConvertNonNumVal;;

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -18,6 +18,7 @@ and expVal =
   | NumVal of int
   | BoolVal of bool
   | ProcVal of procedure
+  | RefVal of int
 and procedure =
   | Procedure of symbol * expression * environment
 ;;
@@ -80,6 +81,12 @@ exception CannotConvertNonProcVal;;
 let expValToProc = function
   | ProcVal p -> p
   | _ -> raise CannotConvertNonProcVal
+;;
+
+exception CannotConvertNonRefVal;;
+let expValToRef = function
+  | RefVal n -> n
+  | _ -> raise CannotConvertNonRefVal
 ;;
 
 

--- a/ch04/explicit-ref.ml
+++ b/ch04/explicit-ref.ml
@@ -29,10 +29,10 @@ type store =
 
 let the_store = ref EmptyStore;;
 
-let get_store () = the_store;;
-let initialize_store = the_store := EmptyStore;;
+let getStore () = the_store;;
+let initializeStore = the_store := EmptyStore;;
 let new_ref v =
-    let s = get_store () in
+    let s = getStore () in
     let r = !s in
     let n = match r with
               | EmptyStore -> 0
@@ -49,7 +49,7 @@ let rec applyStore s ref = match s with
           if n = ref then v
           else applyStore store1 ref
 ;;
-let deref ref = applyStore !(get_store ()) ref;;
+let deref ref = applyStore !(getStore ()) ref;;
 
 let rec modifyStore s ref nv = match s with
   | EmptyStore  -> raise StoreNotFound
@@ -58,7 +58,7 @@ let rec modifyStore s ref nv = match s with
           else AppendStore (n, v, modifyStore store1 ref nv)
 ;;
 let setref ref v =
-    let s = get_store () in
+    let s = getStore () in
     s := modifyStore !s ref v
 ;;
 


### PR DESCRIPTION
Extend PROC language with global state references
 - NewRefExp to allocate new ref variable
 - DerefExp to get the value stored in a ref variable
 - SetRefExp to alter the value of an existing ref variable