### PR TITLE
CALL-BY-REFERENCE

### DIFF
--- a/ch04/call-by-reference.ml
+++ b/ch04/call-by-reference.ml
@@ -145,7 +145,11 @@ let rec valueOf exp env = match exp with
           ProcVal (Procedure (var, body, env))
   | CallExp (func, arg) ->
           let p = expValToProc (valueOf func env) in
-          applyProcedure p (valueOf arg env)
+          let v = match arg with
+                    | VarExp var -> valueOf arg env
+                    | _ -> RefVal (newRef (valueOf arg env))
+          in
+          applyProcedure p v
   | AssignExp (var, exp1) ->
           let val1 = valueOf exp1 env in
           (setRef (expValToRef (applyEnv env var)) val1; val1)
@@ -168,8 +172,7 @@ let rec valueOf exp env = match exp with
 
 and applyProcedure p v = match p with
   | Procedure (var, body, senv) ->
-          let rv = RefVal (newRef v) in
-          valueOf body (ExtendEnv (var, rv, senv))
+          valueOf body (ExtendEnv (var, v, senv))
 ;;
 
 let valueOfProgram = function


### PR DESCRIPTION
Modification of MUTABLE-PAIRS to change procedure parameter passing strategy (but not let-bindings) to be call-by-reference rather than call-by-value