### PR TITLE
CALL-BY-NAME

### DIFF
--- a/ch04/call-by-name.ml
+++ b/ch04/call-by-name.ml
@@ -26,10 +26,13 @@ and expVal =
   | ProcVal of procedure
   | RefVal of int
   | MutablePairVal of mutablePair
+  | ThunkVal of thunk
 and procedure =
   | Procedure of symbol * expression * environment
 and mutablePair =
   | MutablePair of int * int
+and thunk =
+  | Thunk of expression * environment
 ;;
 
 type store =
@@ -111,6 +114,12 @@ exception CannotConvertNonMutablePairVal;;
 let expValToMutablePair = function
   | MutablePairVal p -> p
   | _ -> raise CannotConvertNonMutablePairVal
+;;
+
+exception CannotConvertNonThunkVal;;
+let expValToThunk = function
+  | ThunkVal n -> n
+  | _ -> raise CannotConvertNonThunkVal
 ;;
 
 

--- a/ch04/call-by-name.ml
+++ b/ch04/call-by-name.ml
@@ -146,7 +146,10 @@ let rec valueOf exp env = match exp with
           then valueOf e2 env
           else valueOf e3 env
   | VarExp var ->
-          deref (expValToRef (applyEnv env var))
+          let v = deref (expValToRef (applyEnv env var)) in
+          (match v with
+             | ThunkVal (Thunk (exp1, env1)) -> valueOf exp1 env1
+             | _ -> v)
   | LetExp (var, e, body) ->
           let rv = RefVal (newRef (valueOf e env)) in
           valueOf body (ExtendEnv (var, rv, env))

--- a/ch04/call-by-name.ml
+++ b/ch04/call-by-name.ml
@@ -154,7 +154,11 @@ let rec valueOf exp env = match exp with
           ProcVal (Procedure (var, body, env))
   | CallExp (func, arg) ->
           let p = expValToProc (valueOf func env) in
-          applyProcedure p (valueOf arg env)
+          let v = match arg with
+                    | VarExp var -> applyEnv env var
+                    | _ -> RefVal (newRef (ThunkVal (Thunk (arg, env))))
+          in
+          applyProcedure p v
   | AssignExp (var, exp1) ->
           let val1 = valueOf exp1 env in
           (setRef (expValToRef (applyEnv env var)) val1; val1)
@@ -177,8 +181,7 @@ let rec valueOf exp env = match exp with
 
 and applyProcedure p v = match p with
   | Procedure (var, body, senv) ->
-          let rv = RefVal (newRef v) in
-          valueOf body (ExtendEnv (var, rv, senv))
+          valueOf body (ExtendEnv (var, v, senv))
 ;;
 
 let valueOfProgram = function


### PR DESCRIPTION
Modification of MUTABLE-PAIRS to change procedure parameter passing strategy (but not let-bindings) to be call-by-name lazy-evaluation rather than call-by-value